### PR TITLE
Add support for gpio reset on smhub 6.18 kernel

### DIFF
--- a/smlight_cc_flasher/command.py
+++ b/smlight_cc_flasher/command.py
@@ -179,7 +179,7 @@ class Bootloader:
             if await client.check_auth_needed():
                 return False
 
-            return bool(await client.set_cmd(Commands.CMD_ZB_BSL))  # type: ignore[attr-defined]
+            return bool(await client.set_cmd(Commands.CMD_ZB_BSL))
 
 
 class CommandInterface:

--- a/smlight_cc_flasher/gpio.py
+++ b/smlight_cc_flasher/gpio.py
@@ -34,6 +34,15 @@ class GpioConfig:
 
 gpioResets = {
     "smhub": GpioConfig(
+        chip="gpiochip2",
+        patterns=[
+            GpioPattern(pins={11: True, 12: True}, delay_after=0.1),
+            GpioPattern(pins={11: False, 12: False}, delay_after=0.1),
+            GpioPattern(pins={11: True, 12: False}, delay_after=0.1),
+            GpioPattern(pins={11: True, 12: True}, delay_after=0.1),
+        ],
+    ),
+    "smhub-1": GpioConfig(
         chip="gpiochip1",
         patterns=[
             GpioPattern(pins={11: True, 12: True}, delay_after=0.1),
@@ -41,7 +50,7 @@ gpioResets = {
             GpioPattern(pins={11: True, 12: False}, delay_after=0.1),
             GpioPattern(pins={11: True, 12: True}, delay_after=0.1),
         ],
-    )
+    ),
 }
 
 


### PR DESCRIPTION
We keep support for the old config for compat with vendor kernel